### PR TITLE
Add --branch option

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,3 +63,11 @@ repo-growth --end 2018-01
 ```sh
 repo-growth --freq 7
 ```
+
+#### `--branch`, `-b`
+
+**Default: "master"**
+
+```sh
+repo-growth --branch production
+```

--- a/cli.js
+++ b/cli.js
@@ -18,10 +18,12 @@ const cli = meow({
       --end, -e <date>        End Date
       --freq, -f <days>       Frequency (in days)
       --json                  Output JSON
+      --branch, -b <branch>   Select the branch used
 
     Examples
       $ repo-growth
       $ repo-growth -s 2017-01 -e 2018-01 -f 365
+      $ repo-growth --branch production
 
     Dates
       Dates should be formatted YYYY-MM
@@ -38,6 +40,10 @@ const cli = meow({
     freq: {
       type: 'number',
       alias: 'f'
+    },
+    branch: {
+      type: 'string',
+      alias: 'b'
     },
     '--': true
   },
@@ -65,6 +71,7 @@ opts.cwd = process.cwd();
 if (cli.flags.start) opts.start = toDate(cli.flags.start);
 if (cli.flags.end) opts.end = toDate(cli.flags.end);
 if (cli.flags.freq) opts.freq = cli.flags.freq;
+if (cli.flags.branch) opts.branch = cli.flags.branch;
 if (cli.flags['--']) opts.clocArgs = cli.flags['--'];
 
 repoGrowth(opts).then(() => {

--- a/index.js
+++ b/index.js
@@ -155,6 +155,7 @@ async function repoGrowth(opts /*: Opts */ = {}) {
   let end = opts.end || new Date();
   let freq = opts.freq || 30;
   let clocArgs = opts.clocArgs || [];
+  let branch = opts.branch || 'master';
 
   let current = start;
   let dates = [];
@@ -168,7 +169,7 @@ async function repoGrowth(opts /*: Opts */ = {}) {
 
   let periods = [];
 
-  await checkout(cwd, 'master');
+  await checkout(cwd, branch);
 
   let prevCommit;
 
@@ -198,7 +199,7 @@ async function repoGrowth(opts /*: Opts */ = {}) {
     allResults.push({ date: period.date, commit: period.commit, results });
   }
 
-  await checkout(cwd, 'master');
+  await checkout(cwd, branch);
   console.log();
 
   console.log(chalk.cyan('Results:'));


### PR DESCRIPTION
Our default branch is `alpha`, not `master`, so this tool currently fails on us. This patch adds a `--branch` option, which allows me to select any branch to be used.

> Note: This PR was made entirely via the GitHub web interface and is completely untested. Please test it before merging.